### PR TITLE
add  Qgis task manager usage choice in settings

### DIFF
--- a/ClassMascaret.py
+++ b/ClassMascaret.py
@@ -1854,17 +1854,19 @@ class ClassMascaret:
             self.fct_only_init(noyau)
             return
 
-        # self.task_mascaret(None,tup=(par, dict_scen, dict_lois,
-        #                                               comments, noyau, run))
-        self.mgis.task_mas = QgsTask.fromFunction('Run Mascaret',
-                                                  self.task_mascaret,
-                                                  on_finished=self.completed,
-                                                  tup=(
-                                                      par, dict_scen, dict_lois,
-                                                      comments, noyau, run))
-        self.mgis.task_mas.taskCompleted.connect(self.del_task_mas)
-        self.mgis.task_mas.taskTerminated.connect(self.del_task_mas)
-        QgsApplication.taskManager().addTask(self.mgis.task_mas)
+        #
+        if self.mgis.task_use :
+            self.mgis.task_mas = QgsTask.fromFunction('Run Mascaret',
+                                                      self.task_mascaret,
+                                                      on_finished=self.completed,
+                                                      tup=(
+                                                          par, dict_scen, dict_lois,
+                                                          comments, noyau, run))
+            self.mgis.task_mas.taskCompleted.connect(self.del_task_mas)
+            self.mgis.task_mas.taskTerminated.connect(self.del_task_mas)
+            QgsApplication.taskManager().addTask(self.mgis.task_mas)
+        else:
+            self.task_mascaret(None, tup=(par, dict_scen, dict_lois, comments, noyau, run))
 
     def del_task_mas(self):
         """

--- a/ClassSettingsDialog.py
+++ b/ClassSettingsDialog.py
@@ -56,6 +56,7 @@ class ClassSettingsDialog(QDialog):
         #     self.ui.apiChbox.hide()
         # api
         self.ui.apiChbox.setChecked(self.mgis.cond_api)
+        self.ui.taskQChbox.setChecked(self.mgis.task_use)
 
         self.ui.debugModeChbox.setChecked(self.mgis.DEBUG)
         # DB
@@ -74,6 +75,7 @@ class ClassSettingsDialog(QDialog):
         self.mgis.open_last_schema = self.ui.open_lastChbox_schema.isChecked()
         self.mgis.cond_api = self.ui.apiChbox.isChecked()
         self.mgis.DEBUG = self.ui.debugModeChbox.isChecked()
+        self.mgis.task_use = self.ui.taskQChbox.isChecked()
         # Mascaret DB
         self.mgis.mdb.OVERWRITE = True
         self.mgis.mdb.LOAD_ALL = True

--- a/MascPlugDialog.py
+++ b/MascPlugDialog.py
@@ -69,6 +69,7 @@ class MascPlugDialog(QMainWindow):
             os.path.join(self.masplugPath, 'ui/MascPlug_dialog_base.ui'), self)
         # variables
         self.DEBUG = 1
+        self.task_use = True
 
         self.curConnName = None
         self.passwd = None

--- a/db/Check_tab.py
+++ b/db/Check_tab.py
@@ -80,6 +80,7 @@ class CheckTab:
                                   '4.0.14',
                                   '5.0.1',
                                   '5.0.2',
+                                  '5.0.3',
                                   ]
         self.dico_modif = {'3.0.0': {
             'add_tab': [{'tab': Maso.struct_config, 'overwrite': False},
@@ -227,6 +228,7 @@ class CheckTab:
             '4.0.14': {},
             '5.0.1': {},
             '5.0.2': {'fct': [lambda: self.change_clone_shema_trigger()], },
+            '5.0.3': {},
             # '3.0.x': { },
 
         }

--- a/default_settings.json
+++ b/default_settings.json
@@ -5,7 +5,8 @@
   "open_last_conn": false,
   "open_last_schema": false,
    "postgres_path": ".",
-  "cond_api": false
+  "cond_api": false,
+  "task_use" : true
   },
 
   "mdb": {

--- a/metadata.txt
+++ b/metadata.txt
@@ -20,7 +20,7 @@ qgisMinimumVersion=3.10
 qgisMaximumVersion=3.99
 
 
-version=5.0.2
+version=5.0.3
 
 author=Artelia
 email=mehdi-pierre.daou@arteliagroup.com
@@ -31,6 +31,7 @@ email=mehdi-pierre.daou@arteliagroup.com
 
 # Uncomment the following line and add your changelog:
 changelog=
+    5.0.3  : Addition of Qgis task manager usage choice in settings
     5.0.2  : Correction of clone_schema function about trigger cloning
     5.0.1  : Merge Master
     4.0.14 : Correction of export results function

--- a/ui/structures/ui_borda_da.ui
+++ b/ui/structures/ui_borda_da.ui
@@ -487,7 +487,7 @@
    <item>
     <widget class="QTabWidget" name="clas_met">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="ong_trav">
       <attribute name="title">

--- a/ui/ui_settings.ui
+++ b/ui/ui_settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>620</width>
-    <height>473</height>
+    <height>466</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -114,6 +114,16 @@
        <widget class="QCheckBox" name="debugModeChbox">
         <property name="text">
          <string>Debugging mode</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="taskQChbox">
+        <property name="text">
+         <string>Using taskmanager for the run</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
In view of the stability problem during the sequence of calculations due to the Qgis task manager, it has been made usable or not in the Setting menu (image below) for the moment.

![image](https://user-images.githubusercontent.com/6881363/195865029-955cc148-c55e-4b77-a7b8-7088b7bd588d.png)
